### PR TITLE
Update GitHub Actions workflows

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -6,6 +6,10 @@ TODO write docs for staff here
 
 TODO Info here about workflows and links
 
+Most of the linters in `.github/workflows/linters.yml` are powered by [reviewdog](https://github.com/reviewdog/reviewdog).
+
+Run `bundle exec rubocop` to run [Rubocop](https://rubocop.org/). To autocorrect certain errors, run `bundle exec rubocop --autocorrect`.
+
 ## Testing
 
 To run tests, run `bundle exec rspec`

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -18,6 +18,8 @@ jobs:
           # GitHub Status Check won't become failure with warning.
           level: warning
           glob_pattern: "**/*.py"
+          filter_mode: nofilter
+          fail_on_error: true
   
   black:
     name: runner / black
@@ -29,11 +31,13 @@ jobs:
         id: action_black
         with:
           black_args: "."
+          fail_on_error: true
       - name: Annotate diff changes using reviewdog
         if: steps.action_black.outputs.is_formatted == 'true'
         uses: reviewdog/action-suggester@v1
         with:
           tool_name: blackfmt
+          # NOTE: the reviewdog filter_mode is diff_context - this is the only thing supported by GitHub suggestions
   
   markdownlint:
     name: runner / markdownlint
@@ -45,6 +49,8 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-check
+          filter_mode: nofilter
+          fail_on_error: true
   
   rubocop:
     name: runner / rubocop
@@ -62,3 +68,5 @@ jobs:
           reporter: github-pr-check
           skip_install: true
           use_bundler: true
+          filter_mode: nofilter
+          fail_on_error: true

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -1,5 +1,8 @@
 name: Linters
 on: [pull_request]
+permissions:
+  contents: read
+  pull-requests: write
 jobs:
   pylint:
     name: runner / pylint

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -1,4 +1,4 @@
-name: reviewdog
+name: Linters
 on: [pull_request]
 jobs:
   pylint:
@@ -42,3 +42,20 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           reporter: github-pr-check
+  
+  rubocop:
+    name: runner / rubocop
+    runs-on: ubuntu-latest
+    env:
+      BUNDLE_ONLY: rubocop
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+      - uses: reviewdog/action-rubocop@v2
+        with:
+          reporter: github-pr-check
+          skip_install: true
+          use_bundler: true

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -1,6 +1,6 @@
-name: Run rspec tests
+name: Run all page tests
 
-on: [pull_request]
+on: [pull_request, push]
 
 jobs:
   build:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,2 @@
+AllCops:
+  NewCops: enable

--- a/Gemfile
+++ b/Gemfile
@@ -4,15 +4,15 @@ gem 'jekyll-sitemap'
 gem 'webrick'
 
 group :development, :test do
-    gem "rspec"
-    gem "selenium-webdriver"
-    gem "capybara"
-    gem "rack-jekyll"
-    gem "axe-core-rspec"
-    gem "axe-core-capybara"
+  gem 'axe-core-capybara'
+  gem 'axe-core-rspec'
+  gem 'capybara'
+  gem 'rack-jekyll'
+  gem 'rspec'
+  gem 'selenium-webdriver'
 end
 
 group :development, :rubocop do
-    gem "rubocop", require: false
-    gem "rubocop-rspec", require: false
+  gem 'rubocop', require: false
+  gem 'rubocop-rspec', require: false
 end

--- a/Gemfile
+++ b/Gemfile
@@ -11,3 +11,8 @@ group :development, :test do
     gem "axe-core-rspec"
     gem "axe-core-capybara"
 end
+
+group :development, :rubocop do
+    gem "rubocop", require: false
+    gem "rubocop-rspec", require: false
+end

--- a/spec/accessibility_spec.rb
+++ b/spec/accessibility_spec.rb
@@ -1,18 +1,18 @@
-describe "course website", type: :feature, js: true do
+describe 'course website', type: :feature, js: true do
   before :all do
     visit('/sitemap.xml')
-    sitemap_links = page.html.scan(/<loc>.+<\/loc>/)
+    sitemap_links = page.html.scan(%r{<loc>.+</loc>})
     @links = []
     sitemap_links.each do |link|
-      # TODO don't hardcode base url
+      # TODO: don't hardcode base url
       first_removed = link.sub('<loc>https://phrdang.github.io/berkeley-class-site', '')
       last_removed = first_removed.sub('</loc>', '')
       @links.push(last_removed)
     end
   end
 
-  # TODO run each page's axe check separately so it doesn't exit on first failure
-  it "is accessible" do
+  # TODO: run each page's axe check separately so it doesn't exit on first failure
+  it 'is accessible' do
     @links.each do |link|
       visit(link)
       expect(page).to be_axe_clean.according_to :wcag2a, "path: #{link} not accessible"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -72,7 +72,7 @@ RSpec.configure do |config|
 
   # https://stackoverflow.com/questions/52506822/testing-a-jekyll-site-with-rspec-and-capybara-getting-a-bizarre-race-case-on-rs
   sleep 0.1 while jekyll_app.compiling?
-  
+
   Capybara.app = jekyll_app
 
   # Configure Capybara server (otherwise it will error and say to use webrick or puma)


### PR DESCRIPTION
- Rename reviewdog.yml to linters.yml
- Add Rubocop job to linters.yml: https://github.com/reviewdog/action-rubocop
- Add `.rubocop.yml` config (blank file for now) and install rubocop gems
- Add Rubocop docs to CONTRIBUTING.md
- Set `filter_mode: nofilter` and `fail_on_error: true` for reviewdog linters so the linters check all files (not just the ones in the PR) and the CI checks show up red if there are linter errors
- In rspec.yml change name to "Run all page tests" and run on all pushes